### PR TITLE
feat: add IP-based access control for dashboard

### DIFF
--- a/config/config.example.ini
+++ b/config/config.example.ini
@@ -4,6 +4,9 @@
 
 [server]
 port = 6942
+# Comma-separated list of IPs allowed to access the dashboard and dashboard APIs.
+# If empty or commented out, all IPs are allowed.
+allowed_dashboard_ips = 127.0.0.1, 192.168.1.100
 
 [database]
 host = localhost
@@ -60,14 +63,14 @@ top_tier_load_percentage = 50
 
 # 高质量代理池大小，默认20
 premium_pool_size = 20
-# 最小使用次数要求，默认50         
+# 最小使用次数要求，默认50
 premium_min_usage_count = 50
 
-# ELO 滑动窗口配置  
+# ELO 滑动窗口配置
 # 每个代理保留的最大结果数
 elo_max_window = 100
-# 用于计算分数的结果数         
-elo_scoring_window = 50       
+# 用于计算分数的结果数
+elo_scoring_window = 50
 # 是否启用按时间衰减（越旧数据权重越低）
 elo_time_decay_enabled = true
 # 时间衰减半衰期（小时）

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -16,6 +16,38 @@ def create_app(proxy_manager: ProxyManager):
     app = Flask(__name__, static_folder="../../dashboard/dist")
     CORS(app)
     
+    @app.before_request
+    def restrict_dashboard_access():
+        """Restrict access to the dashboard and dashboard-specific APIs by IP."""
+        # Only apply restriction if allowed_ips is configured
+        if not proxy_manager.allowed_dashboard_ips:
+            return
+
+        # Define paths that are considered part of the dashboard/monitoring
+        # 1. Root and frontend static files (handled by serve_frontend)
+        # 2. Dashboard-specific APIs starting with /api/
+        # 3. Monitoring endpoints /health and /metrics (optional, but usually part of dashboard)
+        path = request.path
+        is_dashboard_api = path.startswith("/api/")
+        is_monitoring = path in ["/health", "/metrics"]
+        
+        # We also need to check if it's hitting the serve_frontend route (root or file paths)
+        # In Flask, the static folder and catch-all routes cover the frontend.
+        # If it's not a proxy/feedback/reload API, it's likely dashboard-related.
+        proxy_apis = ["/get-proxy", "/get-premium-proxy", "/feedback", "/reload-sources", "/backup-stats"]
+        is_frontend = path == "/" or path not in proxy_apis
+        
+        if is_dashboard_api or is_monitoring or is_frontend:
+            client_ip = request.remote_addr
+            
+            # Always allow local loopback addresses
+            if client_ip in ["127.0.0.1", "::1"]:
+                return
+
+            if client_ip not in proxy_manager.allowed_dashboard_ips:
+                logger.warning(f"Unauthorized dashboard access attempt from IP: {client_ip} for path: {path}")
+                return jsonify({"error": "Forbidden: Your IP is not authorized to access the dashboard."}), 403
+
     # Store proxy_manager in app config or closure, but here passing it explicitly 
     # to routes via closure or global usage might be cleaner if we use a blueprint.
     # For now, let's keep it simple and register routes within this function

--- a/src/core/proxy_manager.py
+++ b/src/core/proxy_manager.py
@@ -67,6 +67,11 @@ class ProxyManager:
 
     def _load_config(self):
         self.server_port = self.config.getint("server", "port", fallback=6942)
+        allowed_ips_str = self.config.get("server", "allowed_dashboard_ips", fallback="")
+        self.allowed_dashboard_ips = [
+            ip.strip() for ip in allowed_ips_str.split(",") if ip.strip()
+        ]
+
         self.validation_workers = self.config.getint(
             "validator", "validation_workers", fallback=100
         )

--- a/tests/test_ip_restriction.py
+++ b/tests/test_ip_restriction.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+import unittest
+from unittest.mock import MagicMock, patch
+from flask import Flask
+import json
+
+from src.core.proxy_manager import ProxyManager
+from src.api.server import create_app
+
+class TestIPRestriction(unittest.TestCase):
+    def setUp(self):
+        # Mock ProxyManager
+        self.mock_proxy_manager = MagicMock(spec=ProxyManager)
+        self.mock_proxy_manager.allowed_dashboard_ips = []
+        self.mock_proxy_manager.lock = MagicMock()
+        self.mock_proxy_manager.active_proxies = set()
+        self.mock_proxy_manager.premium_proxies = []
+        self.mock_proxy_manager.predefined_sources = set()
+        self.mock_proxy_manager.dashboard_sources = set()
+        self.mock_proxy_manager.is_validating = False
+        
+        # Create Flask app
+        self.app = create_app(self.mock_proxy_manager)
+        self.client = self.app.test_client()
+
+    def test_no_restriction_when_ips_not_configured(self):
+        """When allowed_dashboard_ips is empty, all IPs should have access."""
+        self.mock_proxy_manager.allowed_dashboard_ips = []
+        
+        # Test dashboard access
+        response = self.client.get("/", environ_overrides={'REMOTE_ADDR': '1.2.3.4'})
+        # Since static folder might not exist in test env, we look for 200 or 404 (not 403)
+        # But "/" is explicitly handled in server.py to return index.html
+        self.assertNotEqual(response.status_code, 403)
+        
+        # Test API access
+        response = self.client.get("/api/sources", environ_overrides={'REMOTE_ADDR': '1.2.3.4'})
+        self.assertNotEqual(response.status_code, 403)
+
+    def test_restriction_when_ips_configured(self):
+        """When allowed_dashboard_ips is set, unauthorized IPs should be blocked."""
+        self.mock_proxy_manager.allowed_dashboard_ips = ["127.0.0.1", "192.168.1.1"]
+        
+        # Unauthorized IP
+        unauth_ip = "8.8.8.8"
+        
+        # 1. Block dashboard root
+        response = self.client.get("/", environ_overrides={'REMOTE_ADDR': unauth_ip})
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("Forbidden", response.get_json()["error"])
+        
+        # 2. Block dashboard API
+        response = self.client.get("/api/sources", environ_overrides={'REMOTE_ADDR': unauth_ip})
+        self.assertEqual(response.status_code, 403)
+        
+        # 3. Block monitoring
+        response = self.client.get("/health", environ_overrides={'REMOTE_ADDR': unauth_ip})
+        self.assertEqual(response.status_code, 403)
+
+    def test_allow_authorized_ip(self):
+        """Authorized IPs should still have access."""
+        self.mock_proxy_manager.allowed_dashboard_ips = ["127.0.0.1"]
+        auth_ip = "127.0.0.1"
+        
+        # Access health (should not be 403)
+        response = self.client.get("/health", environ_overrides={'REMOTE_ADDR': auth_ip})
+        self.assertNotEqual(response.status_code, 403)
+        
+        # Access API (should not be 403)
+        response = self.client.get("/api/sources", environ_overrides={'REMOTE_ADDR': auth_ip})
+        self.assertNotEqual(response.status_code, 403)
+
+    def test_proxy_api_always_allowed(self):
+        """Core proxy APIs should be accessible from any IP (as they are usually used by services)."""
+        self.mock_proxy_manager.allowed_dashboard_ips = ["127.0.0.1"]
+        unauth_ip = "8.8.8.8"
+        
+        # Mock get_proxy to return something
+        self.mock_proxy_manager.get_proxy.return_value = "http://proxy:8080"
+        
+        # Access /get-proxy (should be 200, not 403)
+        response = self.client.get("/get-proxy?source=default", environ_overrides={'REMOTE_ADDR': unauth_ip})
+        self.assertEqual(response.status_code, 200)
+        
+        # Access /feedback (should be 400 because of missing data, but NOT 403)
+        response = self.client.post("/feedback", json={}, environ_overrides={'REMOTE_ADDR': unauth_ip})
+        self.assertEqual(response.status_code, 400)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implement IP-based access control for the dashboard, allowing only authorized IPs and local loopback addresses. Version bumped to 0.0.1.