### PR TITLE
Enforce global IP access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ The service is configured via the config.ini file.
 
 * **\[database\]**: Credentials for your PostgreSQL database.  
 * **\[server\]**: port for the API and dashboard.  
+  * allowed\_ips: Comma-separated remote IP allowlist for external APIs and dashboard pages.
+  * localhost (127.0.0.1 / ::1) is always allowed automatically.
+  * internal endpoints `/health`, `/metrics`, `/reload-sources`, `/backup-stats` are localhost-only.
 * **\[validator\]**:  
   * validation\_target: URL used to test proxy connectivity.  
   * validation\_workers: Number of concurrent threads for validation.  

--- a/config/config.example.ini
+++ b/config/config.example.ini
@@ -4,9 +4,10 @@
 
 [server]
 port = 6942
-# Comma-separated list of IPs allowed to access the dashboard and dashboard APIs.
-# If empty or commented out, all IPs are allowed.
-allowed_dashboard_ips = 127.0.0.1, 192.168.1.100
+# Comma-separated list of remote IPs allowed for external APIs and dashboard pages.
+# Localhost (127.0.0.1 / ::1) is always allowed automatically.
+# Internal-only endpoints (/health, /metrics, /reload-sources, /backup-stats) are localhost-only.
+allowed_ips = 192.168.1.100
 
 [database]
 host = localhost

--- a/src/core/proxy_manager.py
+++ b/src/core/proxy_manager.py
@@ -67,10 +67,17 @@ class ProxyManager:
 
     def _load_config(self):
         self.server_port = self.config.getint("server", "port", fallback=6942)
-        allowed_ips_str = self.config.get("server", "allowed_dashboard_ips", fallback="")
-        self.allowed_dashboard_ips = [
-            ip.strip() for ip in allowed_ips_str.split(",") if ip.strip()
-        ]
+        allowed_ips_str = self.config.get("server", "allowed_ips", fallback="")
+        if not allowed_ips_str:
+            legacy_allowed_ips = self.config.get(
+                "server", "allowed_dashboard_ips", fallback=""
+            )
+            if legacy_allowed_ips:
+                logger.warning(
+                    "Config key 'allowed_dashboard_ips' is deprecated. Use 'allowed_ips' instead."
+                )
+                allowed_ips_str = legacy_allowed_ips
+        self.allowed_ips = [ip.strip() for ip in allowed_ips_str.split(",") if ip.strip()]
 
         self.validation_workers = self.config.getint(
             "validator", "validation_workers", fallback=100

--- a/tests/test_ip_restriction.py
+++ b/tests/test_ip_restriction.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
-from unittest.mock import MagicMock, patch
-from flask import Flask
-import json
+from unittest.mock import MagicMock
 
 from src.core.proxy_manager import ProxyManager
 from src.api.server import create_app
@@ -11,7 +9,7 @@ class TestIPRestriction(unittest.TestCase):
     def setUp(self):
         # Mock ProxyManager
         self.mock_proxy_manager = MagicMock(spec=ProxyManager)
-        self.mock_proxy_manager.allowed_dashboard_ips = []
+        self.mock_proxy_manager.allowed_ips = []
         self.mock_proxy_manager.lock = MagicMock()
         self.mock_proxy_manager.active_proxies = set()
         self.mock_proxy_manager.premium_proxies = []
@@ -23,68 +21,52 @@ class TestIPRestriction(unittest.TestCase):
         self.app = create_app(self.mock_proxy_manager)
         self.client = self.app.test_client()
 
-    def test_no_restriction_when_ips_not_configured(self):
-        """When allowed_dashboard_ips is empty, all IPs should have access."""
-        self.mock_proxy_manager.allowed_dashboard_ips = []
-        
-        # Test dashboard access
-        response = self.client.get("/", environ_overrides={'REMOTE_ADDR': '1.2.3.4'})
-        # Since static folder might not exist in test env, we look for 200 or 404 (not 403)
-        # But "/" is explicitly handled in server.py to return index.html
-        self.assertNotEqual(response.status_code, 403)
-        
-        # Test API access
-        response = self.client.get("/api/sources", environ_overrides={'REMOTE_ADDR': '1.2.3.4'})
-        self.assertNotEqual(response.status_code, 403)
+    def test_external_endpoint_blocks_remote_when_not_in_allowed_ips(self):
+        """External endpoints should reject remote clients not in allowed_ips."""
+        self.mock_proxy_manager.allowed_ips = []
 
-    def test_restriction_when_ips_configured(self):
-        """When allowed_dashboard_ips is set, unauthorized IPs should be blocked."""
-        self.mock_proxy_manager.allowed_dashboard_ips = ["127.0.0.1", "192.168.1.1"]
-        
-        # Unauthorized IP
-        unauth_ip = "8.8.8.8"
-        
-        # 1. Block dashboard root
-        response = self.client.get("/", environ_overrides={'REMOTE_ADDR': unauth_ip})
+        response = self.client.get(
+            "/get-proxy?source=default", environ_overrides={"REMOTE_ADDR": "8.8.8.8"}
+        )
         self.assertEqual(response.status_code, 403)
         self.assertIn("Forbidden", response.get_json()["error"])
-        
-        # 2. Block dashboard API
-        response = self.client.get("/api/sources", environ_overrides={'REMOTE_ADDR': unauth_ip})
-        self.assertEqual(response.status_code, 403)
-        
-        # 3. Block monitoring
-        response = self.client.get("/health", environ_overrides={'REMOTE_ADDR': unauth_ip})
-        self.assertEqual(response.status_code, 403)
 
-    def test_allow_authorized_ip(self):
-        """Authorized IPs should still have access."""
-        self.mock_proxy_manager.allowed_dashboard_ips = ["127.0.0.1"]
-        auth_ip = "127.0.0.1"
-        
-        # Access health (should not be 403)
-        response = self.client.get("/health", environ_overrides={'REMOTE_ADDR': auth_ip})
-        self.assertNotEqual(response.status_code, 403)
-        
-        # Access API (should not be 403)
-        response = self.client.get("/api/sources", environ_overrides={'REMOTE_ADDR': auth_ip})
-        self.assertNotEqual(response.status_code, 403)
+    def test_external_endpoint_allows_configured_remote_ip(self):
+        """Configured remote IPs should access external endpoints."""
+        self.mock_proxy_manager.allowed_ips = ["8.8.8.8"]
 
-    def test_proxy_api_always_allowed(self):
-        """Core proxy APIs should be accessible from any IP (as they are usually used by services)."""
-        self.mock_proxy_manager.allowed_dashboard_ips = ["127.0.0.1"]
-        unauth_ip = "8.8.8.8"
-        
-        # Mock get_proxy to return something
-        self.mock_proxy_manager.get_proxy.return_value = "http://proxy:8080"
-        
-        # Access /get-proxy (should be 200, not 403)
-        response = self.client.get("/get-proxy?source=default", environ_overrides={'REMOTE_ADDR': unauth_ip})
-        self.assertEqual(response.status_code, 200)
-        
-        # Access /feedback (should be 400 because of missing data, but NOT 403)
-        response = self.client.post("/feedback", json={}, environ_overrides={'REMOTE_ADDR': unauth_ip})
+        response = self.client.post(
+            "/feedback",
+            json={},
+            environ_overrides={"REMOTE_ADDR": "8.8.8.8"},
+        )
+        self.assertNotEqual(response.status_code, 403)
         self.assertEqual(response.status_code, 400)
+
+    def test_external_endpoint_always_allows_localhost(self):
+        """Localhost should access external endpoints even when not in allowed_ips."""
+        self.mock_proxy_manager.allowed_ips = ["192.168.1.1"]
+        self.mock_proxy_manager.get_proxy.return_value = "http://proxy:8080"
+
+        response = self.client.get(
+            "/get-proxy?source=default", environ_overrides={"REMOTE_ADDR": "127.0.0.1"}
+        )
+        self.assertNotEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
+
+    def test_internal_endpoints_are_localhost_only(self):
+        """Internal endpoints should reject all non-local clients."""
+        self.mock_proxy_manager.allowed_ips = ["8.8.8.8"]
+
+        for path in ["/health", "/metrics", "/reload-sources", "/backup-stats"]:
+            response = self.client.get(
+                path, environ_overrides={"REMOTE_ADDR": "8.8.8.8"}
+            )
+            if path in ["/reload-sources", "/backup-stats"]:
+                response = self.client.post(
+                    path, environ_overrides={"REMOTE_ADDR": "8.8.8.8"}
+                )
+            self.assertEqual(response.status_code, 403, f"{path} should be blocked")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_smart_proxy.py
+++ b/tests/test_smart_proxy.py
@@ -76,6 +76,29 @@ class TestProxyManager(unittest.TestCase):
         self.manager = ProxyManager("dummy_path.ini")
         self.mock_db_instance = self.MockDatabaseManager.return_value
 
+    # ========== Config Loading Tests ==========
+
+    def test_load_allowed_ips_from_new_key(self):
+        """allowed_ips should be loaded from [server]."""
+        if not self.manager.config.has_section("server"):
+            self.manager.config.add_section("server")
+        self.manager.config.set("server", "allowed_ips", "10.0.0.1, 10.0.0.2")
+
+        self.manager._load_config()
+
+        self.assertEqual(self.manager.allowed_ips, ["10.0.0.1", "10.0.0.2"])
+
+    def test_load_allowed_ips_falls_back_to_legacy_key(self):
+        """Fallback to allowed_dashboard_ips for backward compatibility."""
+        if not self.manager.config.has_section("server"):
+            self.manager.config.add_section("server")
+        self.manager.config.remove_option("server", "allowed_ips")
+        self.manager.config.set("server", "allowed_dashboard_ips", "192.168.0.10")
+
+        self.manager._load_config()
+
+        self.assertEqual(self.manager.allowed_ips, ["192.168.0.10"])
+
     # ========== Core Proxy Selection Tests ==========
     
     def test_get_proxy_returns_proxy_from_pool(self):


### PR DESCRIPTION
- Apply IP validation to all endpoints\n- Split routes into internal-only and external-access groups\n- Rename config key from allowed_dashboard_ips to allowed_ips (with legacy fallback)\n- Update tests and docs